### PR TITLE
Frontend &  API Improvements

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -389,7 +389,7 @@ async def get_dataset_stats(
 
                 total_where = sql.SQL("")
                 if total_where_clauses:
-                    total_where = sql.SQL("WHERE ").join([sql.SQL(""), sql.SQL(" AND ").join(total_where_clauses)])
+                    total_where = sql.SQL("WHERE ") + sql.SQL(" AND ").join(total_where_clauses)
 
                 query_total = sql.SQL("SELECT COUNT(*) as total FROM {table} {where}").format(
                     table=table_identifier,

--- a/api/main.py
+++ b/api/main.py
@@ -46,22 +46,6 @@ app = FastAPI(title="NeuroD3 API", version="1.0.0")
 
 # Allowed filter values
 ALLOWED_SOURCES = {"DANDI", "Kaggle", "OpenNeuro", "PhysioNet"}
-ALLOWED_MODALITIES = {
-    "Behavioral",
-    "Calcium Imaging",
-    "Clinical",
-    "ECG",
-    "EEG",
-    "Electrophysiology",
-    "fMRI",
-    "iEEG",
-    "MEG",
-    "MRI",
-    "NIRS",
-    "PET",
-    "Survey",
-    "X-ray",
-}
 
 # CORS configuration to allow frontend to access the API
 app.add_middleware(
@@ -149,8 +133,10 @@ async def health_check():
 @app.get("/api/datasets")
 async def get_datasets(
     source: Optional[str] = Query(None, description="Filter by source (DANDI, Kaggle, OpenNeuro, PhysioNet)"),
-    modality: Optional[str] = Query(None, description="Filter by modality"),
+    modality: Optional[str] = Query(None, description="Filter by modality (comma-separated for AND)"),
     search: Optional[str] = Query(None, description="Search in title and description"),
+    limit: int = Query(25, ge=1, le=200, description="Max number of datasets to return"),
+    offset: int = Query(0, ge=0, description="Number of datasets to skip"),
 ):
     """
     Fetch neuroscience datasets from the database.
@@ -195,59 +181,55 @@ async def get_datasets(
                 # Build dynamic query based on filters
                 if view_exists:
                     logger.info("Using unified_datasets view for query")
-                    query = """
-                        SELECT
-                            source,
-                            dataset_id as id,
-                            title,
-                            modality,
-                            citations,
-                            url,
-                            description,
-                            created_at,
-                            updated_at
-                        FROM unified_datasets
-                        WHERE 1=1
-                    """
+                    table_name = "unified_datasets"
                 else:
                     # Fallback to neuroscience_datasets table if view doesn't exist
                     logger.warning("unified_datasets view does not exist, falling back to neuroscience_datasets table")
-                    query = """
-                        SELECT
-                            source,
-                            dataset_id as id,
-                            title,
-                            modality,
-                            citations,
-                            url,
-                            description,
-                            created_at,
-                            updated_at
-                        FROM neuroscience_datasets
-                        WHERE 1=1
-                    """
+                    table_name = "neuroscience_datasets"
+
+                base_select = f"""
+                    SELECT
+                        source,
+                        dataset_id as id,
+                        title,
+                        modality,
+                        citations,
+                        url,
+                        description,
+                        created_at,
+                        updated_at
+                    FROM {table_name}
+                    WHERE 1=1
+                """
+                base_count = f"SELECT COUNT(*) as total FROM {table_name} WHERE 1=1"
+                filters = []
                 params = []
 
                 if source:
                     if source not in ALLOWED_SOURCES:
                         raise HTTPException(status_code=400, detail=f"Invalid source: {source}")
-                    query += " AND source = %s"
+                    filters.append("source = %s")
                     params.append(source)
 
                 if modality:
-                    if modality not in ALLOWED_MODALITIES:
-                        raise HTTPException(status_code=400, detail=f"Invalid modality: {modality}")
-                    query += " AND modality = %s"
-                    params.append(modality)
+                    modalities = [m.strip() for m in modality.split(",") if m.strip()]
+                    for m in modalities:
+                        filters.append("modality ILIKE %s")
+                        params.append(f"%{m}%")
 
                 if search:
-                    query += " AND (title ILIKE %s OR description ILIKE %s)"
+                    filters.append("(title ILIKE %s OR description ILIKE %s)")
                     search_pattern = f"%{search}%"
                     params.extend([search_pattern, search_pattern])
 
-                query += " ORDER BY citations DESC, title ASC"
+                filter_sql = f" AND {' AND '.join(filters)}" if filters else ""
+                query = f"{base_select}{filter_sql} ORDER BY citations DESC, title ASC LIMIT %s OFFSET %s"
+                count_query = f"{base_count}{filter_sql}"
 
-                cursor.execute(query, params)
+                cursor.execute(count_query, params)
+                total = cursor.fetchone()["total"]
+
+                cursor.execute(query, params + [limit, offset])
                 datasets = cursor.fetchall()
 
                 # Convert to list of dicts
@@ -255,7 +237,7 @@ async def get_datasets(
 
                 return {
                     "datasets": result,
-                    "count": len(result)
+                    "count": total
                 }
 
     except psycopg.Error as e:
@@ -267,7 +249,10 @@ async def get_datasets(
 
 
 @app.get("/api/datasets/stats")
-async def get_dataset_stats():
+async def get_dataset_stats(
+    source: Optional[str] = Query(None, description="Facet by source (applies to modality counts)"),
+    modality: Optional[str] = Query(None, description="Facet by modality (applies to source counts)"),
+):
     """
     Get statistics about datasets in the database.
     Returns counts by source and modality.
@@ -323,30 +308,94 @@ async def get_dataset_stats():
                 # Use psycopg.sql.Identifier() for safe table name construction
                 table_identifier = sql.Identifier(table_name)
                 
-                # Get counts by source
-                query_source = sql.SQL("""
+                # Parse/validate incoming filters (used for facets/total)
+                if source and source not in ALLOWED_SOURCES:
+                    raise HTTPException(status_code=400, detail=f"Invalid source: {source}")
+                modalities = []
+                if modality:
+                    modalities = [m.strip() for m in modality.split(",") if m.strip()]
+
+                # Facet counts
+                # - by_source: apply modality filter (but not source)
+                # - by_modality: apply source filter (but not modality)
+                by_source_params = []
+                by_source_where = sql.SQL("")
+                if modalities:
+                    by_source_where = sql.SQL("WHERE ") + sql.SQL(" AND ").join([sql.SQL("modality ILIKE %s")] * len(modalities))
+                    by_source_params.extend([f"%{m}%" for m in modalities])
+
+                query_by_source = sql.SQL("""
                     SELECT source, COUNT(*) as count
-                    FROM {}
+                    FROM {table}
+                    {where}
                     GROUP BY source
                     ORDER BY count DESC
-                """).format(table_identifier)
-                cursor.execute(query_source)
-                by_source = {row['source']: row['count'] for row in cursor.fetchall()}
+                """).format(table=table_identifier, where=by_source_where)
+                cursor.execute(query_by_source, by_source_params)
+                by_source = {row["source"]: row["count"] for row in cursor.fetchall()}
 
-                # Get counts by modality
-                query_modality = sql.SQL("""
-                    SELECT modality, COUNT(*) as count
-                    FROM {}
-                    GROUP BY modality
-                    ORDER BY count DESC
-                """).format(table_identifier)
-                cursor.execute(query_modality)
-                by_modality = {row['modality']: row['count'] for row in cursor.fetchall()}
+                by_modality_params = []
+                by_modality_clauses = []
+                if source:
+                    by_modality_clauses.append(sql.SQL("source = %s"))
+                    by_modality_params.append(source)
+                if modalities:
+                    for m in modalities:
+                        by_modality_clauses.append(sql.SQL("modality ILIKE %s"))
+                        by_modality_params.append(f"%{m}%")
 
-                # Get total count
-                query_total = sql.SQL("SELECT COUNT(*) as total FROM {}").format(table_identifier)
-                cursor.execute(query_total)
-                total = cursor.fetchone()['total']
+                by_modality_where = sql.SQL("")
+                if by_modality_clauses:
+                    by_modality_where = sql.SQL("WHERE ") + sql.SQL(" AND ").join(by_modality_clauses)
+
+                # Dynamic modality facets:
+                # - Split comma-separated modality strings into tokens
+                # - Count occurrences across datasets that match current filters (source + selected modalities)
+                query_by_modality = sql.SQL("""
+                    SELECT
+                        CASE
+                            -- Preserve acronyms / tokens containing 2+ consecutive uppercase letters (e.g. EEG, fMRI, iEEG)
+                            -- NOTE: avoid curly-brace quantifiers here because psycopg.sql uses braces for formatting.
+                            WHEN token_raw ~ '.*[A-Z][A-Z]+.*' THEN token_raw
+                            ELSE LOWER(token_raw)
+                        END AS modality,
+                        COUNT(*)::int AS count
+                    FROM (
+                        SELECT
+                            TRIM(regexp_split_to_table(COALESCE(modality, ''), '\\s*[,;]\\s*')) AS token_raw
+                        FROM {table}
+                        {where}
+                    ) t
+                    WHERE token_raw <> ''
+                    GROUP BY 1
+                    ORDER BY count DESC, modality ASC
+                    LIMIT 300
+                """).format(table=table_identifier, where=by_modality_where)
+
+                cursor.execute(query_by_modality, by_modality_params)
+                by_modality = {row["modality"]: row["count"] for row in cursor.fetchall()}
+
+                # Total count (apply BOTH filters)
+                total_where_clauses = []
+                total_params = []
+                if source:
+                    total_where_clauses.append(sql.SQL("source = %s"))
+                    total_params.append(source)
+                if modalities:
+                    for m in modalities:
+                        total_where_clauses.append(sql.SQL("modality ILIKE %s"))
+                        total_params.append(f"%{m}%")
+
+                total_where = sql.SQL("")
+                if total_where_clauses:
+                    total_where = sql.SQL("WHERE ").join([sql.SQL(""), sql.SQL(" AND ").join(total_where_clauses)])
+
+                query_total = sql.SQL("SELECT COUNT(*) as total FROM {table} {where}").format(
+                    table=table_identifier,
+                    where=total_where,
+                )
+                cursor.execute(query_total, total_params)
+                total = cursor.fetchone()["total"]
 
                 return {
                     "total": total,

--- a/api/main.py
+++ b/api/main.py
@@ -223,7 +223,8 @@ async def get_datasets(
                     params.extend([search_pattern, search_pattern])
 
                 filter_sql = f" AND {' AND '.join(filters)}" if filters else ""
-                query = f"{base_select}{filter_sql} ORDER BY citations DESC, title ASC LIMIT %s OFFSET %s"
+                # Default ordering: newest first (published date), then citations
+                query = f"{base_select}{filter_sql} ORDER BY created_at DESC NULLS LAST, citations DESC, title ASC LIMIT %s OFFSET %s"
                 count_query = f"{base_count}{filter_sql}"
 
                 cursor.execute(count_query, params)

--- a/dags/openneuro_ingestion.py
+++ b/dags/openneuro_ingestion.py
@@ -111,6 +111,7 @@ _OPENNEURO_LAST_REQUEST_AT = 0.0
 _OPENNEURO_MODALITY_DEBUG = os.getenv("OPENNEURO_MODALITY_DEBUG", "0").strip().lower() in ("1", "true", "yes")
 _OPENNEURO_MODALITY_DEBUG_SAMPLES = int(os.getenv("OPENNEURO_MODALITY_DEBUG_SAMPLES", "25"))
 _OPENNEURO_MODALITY_DEBUG_LOCK = threading.Lock()
+_OPENNEURO_MODALITY_DEBUG_EMITTED = 0
 
 def _get_dataset_field_specs() -> Dict[str, Dict[str, Any]]:
     """
@@ -1727,8 +1728,8 @@ def _enrich_single_dataset(ds: Dict[str, Any]) -> tuple:
             # Log what we got from OpenNeuro for the first few datasets to help debug
             if _OPENNEURO_MODALITY_DEBUG:
                 with _OPENNEURO_MODALITY_DEBUG_LOCK:
-                    emitted = emitted_local
-                    if emitted < _OPENNEURO_MODALITY_DEBUG_SAMPLES:
+                    global _OPENNEURO_MODALITY_DEBUG_EMITTED
+                    if _OPENNEURO_MODALITY_DEBUG_EMITTED < _OPENNEURO_MODALITY_DEBUG_SAMPLES:
                         logger.info(
                             "OpenNeuro modality debug: dataset=%s desc.Modality=%r dataset.modalities=%r summary.modalities=%r",
                             dataset_id,
@@ -1736,6 +1737,7 @@ def _enrich_single_dataset(ds: Dict[str, Any]) -> tuple:
                             dataset_data.get("modalities") or dataset_data.get("modality"),
                             (summ_obj.get("modalities") if isinstance(summ_obj, dict) else None),
                         )
+                        _OPENNEURO_MODALITY_DEBUG_EMITTED += 1
 
         # public flag
         if "public" in dataset_data:

--- a/dags/utils/openneuro_debugger.py
+++ b/dags/utils/openneuro_debugger.py
@@ -400,7 +400,7 @@ def get_dataset_modalities(dataset_id: str) -> Dict[str, Any]:
 
 def main():
     if len(sys.argv) < 2:
-        print("Usage: python3 openneuro_modality.py ds000001")
+        print("Usage: python3 openneuro_debugger.py ds000001")
         return 2
 
     dataset_id = sys.argv[1].strip()

--- a/frontend/src/components/NeuroDatasetDiscovery.tsx
+++ b/frontend/src/components/NeuroDatasetDiscovery.tsx
@@ -341,7 +341,7 @@ export default function NeuroDatasetDiscovery() {
     if (sortBy === 'published') {
       const aTime = aData.created_at ? Date.parse(aData.created_at) : Number.NEGATIVE_INFINITY;
       const bTime = bData.created_at ? Date.parse(bData.created_at) : Number.NEGATIVE_INFINITY;
-      comparison = (aTime || Number.NEGATIVE_INFINITY) - (bTime || Number.NEGATIVE_INFINITY);
+      comparison = aTime - bTime;
     } else if (sortBy === 'title') comparison = aData.title.localeCompare(bData.title);
     else if (sortBy === 'id') comparison = aData.id.localeCompare(bData.id);
     else if (sortBy === 'source') comparison = aData.source.localeCompare(bData.source);

--- a/frontend/src/components/NeuroDatasetDiscovery.tsx
+++ b/frontend/src/components/NeuroDatasetDiscovery.tsx
@@ -52,6 +52,7 @@ type Dataset = {
   tags?: string | null;
   citations: number;
   url: string;
+  created_at?: string | null;
 };
 
 const SOURCE_OPTIONS = ['DANDI', 'Kaggle', 'OpenNeuro', 'PhysioNet'] as const;
@@ -80,8 +81,8 @@ export default function NeuroDatasetDiscovery() {
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
   const [noDatasetsFound, setNoDatasetsFound] = useState<boolean>(false);
-  const [sortBy, setSortBy] = useState<'citations' | 'title' | 'id' | 'source' | 'modality'>(
-    'citations',
+  const [sortBy, setSortBy] = useState<'published' | 'citations' | 'title' | 'id' | 'source' | 'modality'>(
+    'published',
   );
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
   const [sourceFilter, setSourceFilter] = useState<'all' | 'DANDI' | 'Kaggle' | 'OpenNeuro' | 'PhysioNet'>(
@@ -319,7 +320,11 @@ export default function NeuroDatasetDiscovery() {
     const aData = a;
     const bData = b;
 
-    if (sortBy === 'title') comparison = aData.title.localeCompare(bData.title);
+    if (sortBy === 'published') {
+      const aTime = aData.created_at ? Date.parse(aData.created_at) : Number.NEGATIVE_INFINITY;
+      const bTime = bData.created_at ? Date.parse(bData.created_at) : Number.NEGATIVE_INFINITY;
+      comparison = (aTime || Number.NEGATIVE_INFINITY) - (bTime || Number.NEGATIVE_INFINITY);
+    } else if (sortBy === 'title') comparison = aData.title.localeCompare(bData.title);
     else if (sortBy === 'id') comparison = aData.id.localeCompare(bData.id);
     else if (sortBy === 'source') comparison = aData.source.localeCompare(bData.source);
     else if (sortBy === 'modality') comparison = (aData.modality || '').localeCompare(bData.modality || '');
@@ -710,6 +715,7 @@ export default function NeuroDatasetDiscovery() {
                     <SortableHeader column="source">Source</SortableHeader>
                     <SortableHeader column="title">Dataset Title</SortableHeader>
                     <SortableHeader column="id">ID</SortableHeader>
+                    <SortableHeader column="published">Published</SortableHeader>
                     <SortableHeader column="modality">Modality</SortableHeader>
                     <SortableHeader column="citations">Citations</SortableHeader>
                     <th
@@ -750,6 +756,16 @@ export default function NeuroDatasetDiscovery() {
                             style={{ color: darkMode ? '#E5E7EB' : '#111827' }}
                           >
                             {ds.id}
+                          </td>
+                          <td
+                            className="px-4 py-3 text-sm text-center"
+                            style={{ color: darkMode ? '#E5E7EB' : '#111827' }}
+                          >
+                            <div className="flex justify-center">
+                              <span className="whitespace-nowrap tabular-nums">
+                                {ds.created_at ? new Date(ds.created_at).toLocaleDateString() : '—'}
+                              </span>
+                            </div>
                           </td>
                           <td
                             className="px-4 py-3 text-sm text-center"

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -29,6 +29,8 @@ export interface Dataset {
   citations: number;
   url: string;
   description?: string;
+  created_at?: string;
+  updated_at?: string;
 }
 
 export interface DatasetsResponse {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -52,8 +52,10 @@ export interface ApiHealthResponse {
  */
 export async function fetchDatasets(params?: {
   source?: string;
-  modality?: string;
+  modalities?: string[];
   search?: string;
+  limit?: number;
+  offset?: number;
 }): Promise<DatasetsResponse> {
   try {
     const queryParams = new URLSearchParams();
@@ -61,11 +63,17 @@ export async function fetchDatasets(params?: {
     if (params?.source) {
       queryParams.append('source', params.source);
     }
-    if (params?.modality) {
-      queryParams.append('modality', params.modality);
+    if (params?.modalities?.length) {
+      queryParams.append('modality', params.modalities.join(','));
     }
     if (params?.search) {
       queryParams.append('search', params.search);
+    }
+    if (typeof params?.limit === 'number') {
+      queryParams.append('limit', String(params.limit));
+    }
+    if (typeof params?.offset === 'number') {
+      queryParams.append('offset', String(params.offset));
     }
 
     const url = `${API_BASE_URL}/api/datasets${queryParams.toString() ? `?${queryParams.toString()}` : ''}`;
@@ -85,9 +93,13 @@ export async function fetchDatasets(params?: {
 /**
  * Fetch dataset statistics from the backend API.
  */
-export async function fetchDatasetStats(): Promise<DatasetStats> {
+export async function fetchDatasetStats(params?: { source?: string; modalities?: string[] }): Promise<DatasetStats> {
   try {
-    const url = `${API_BASE_URL}/api/datasets/stats`;
+    const queryParams = new URLSearchParams();
+    if (params?.source) queryParams.append('source', params.source);
+    if (params?.modalities?.length) queryParams.append('modality', params.modalities.join(','));
+
+    const url = `${API_BASE_URL}/api/datasets/stats${queryParams.toString() ? `?${queryParams.toString()}` : ''}`;
 
     const response = await fetch(url);
 


### PR DESCRIPTION
Close #54  & Closes #28 

- Added server-side pagination (25/page) and DB-backed filtering to /api/datasets with total count for paging.
- Wired Source + Modality filters to the URL so links are shareable/restorable.
- Removed the frontend “duplicate grouping” logic and switched to a flat table (no alternates/expands); hid “Unique Datasets”.
- Implemented dependent facets: Source and Modality options update based on the other filter via /api/datasets/stats.
- Made Modality multi-select with AND semantics, supports , and ; separators, and shows modalities as chips.
- Polished UI: centered headers, fixed dropdown z-index/mobile centering, added Foresight link, and made Source/Modality chips clickable to toggle filters with selected styling.
- Also adding published date to the table

<img width="3065" height="1805" alt="image" src="https://github.com/user-attachments/assets/b3ee0f06-561e-4dcf-887c-0e18341eabf3" />
