### PR TITLE
Add durable find-reuse-cache GCS bucket and GCP setup doc

### DIFF
--- a/deploy/gcp/staging/DEPLOY.md
+++ b/deploy/gcp/staging/DEPLOY.md
@@ -145,7 +145,10 @@ terraform output -raw airflow_url    # https://<static-ip> — self-signed cert 
   `terraform apply` (Cloud Run redeploys on the changed ref).
 - **Teardown:** `terraform destroy` works cleanly (`db_deletion_protection = false`,
   buckets `force_destroy = true`). It removes only in-project resources, never the
-  platform-owned project/state bucket.
+  platform-owned project/state bucket. Exception: the `find-reuse-cache` bucket is
+  `force_destroy = false` to protect the expensive-to-regenerate cache, so destroy
+  fails while it holds objects. Empty it first (`gcloud storage rm --recursive
+  gs://neuro-d3-staging-find-reuse-cache/\*`) when you genuinely intend to tear it down.
 
 ---
 

--- a/deploy/gcp/staging/find_reuse_bucket.tf
+++ b/deploy/gcp/staging/find_reuse_bucket.tf
@@ -1,0 +1,50 @@
+# Durable bucket for the find_reuse cache: paper full text, per-archive
+# classification and dataset snapshots, lookup metadata, and the seed manifest
+# (see the seeding epic, Neuro-D3/neurod3#81, for the layout and seeding flow).
+#
+# This is deliberately NOT the paper-mapping bucket above it in storage.tf.
+# That bucket auto-deletes objects after 30 days on the premise that its
+# contents are reproducible by re-running DAGs. The find_reuse cache is the
+# opposite case: it holds multi-source full-text fetches and tens of thousands
+# of LLM classifications that cost weeks and tokens to regenerate. So this
+# bucket has versioning, no lifecycle expiry, and no force_destroy.
+
+resource "google_storage_bucket" "find_reuse_cache" {
+  name                        = "${var.project_id}-find-reuse-cache"
+  location                    = var.region
+  uniform_bucket_level_access = true
+  public_access_prevention    = "enforced"
+  force_destroy               = false
+
+  # Protects against bad uploads and manifest.json regeneration mistakes.
+  # Snapshot files (classifications/, datasets/, manifest.json) are replaced
+  # wholesale on each cache refresh; versioning retains the prior copies.
+  versioning {
+    enabled = true
+  }
+
+  # Keep version storage bounded without ever expiring live objects: retain the
+  # two most recent noncurrent versions and delete older ones. num_newer_versions
+  # counts the live version, so 3 newer versions means 2 archived are kept plus
+  # the live object.
+  lifecycle_rule {
+    condition {
+      num_newer_versions = 3
+      with_state         = "ARCHIVED"
+    }
+    action {
+      type = "Delete"
+    }
+  }
+}
+
+# The Airflow VM reads the cache (seed, classification DAGs) and uploads newly
+# fetched papers (paper-mapping DAGs). Auth is ADC via the VM service account.
+# The API and frontend get no access; full text is never served.
+# Maintainer laptop uploads use the maintainer's own gcloud identity
+# (docs/gcp_setup.md).
+resource "google_storage_bucket_iam_member" "find_reuse_cache_airflow_object_admin" {
+  bucket = google_storage_bucket.find_reuse_cache.name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.airflow.email}"
+}

--- a/docs/gcp_setup.md
+++ b/docs/gcp_setup.md
@@ -1,0 +1,33 @@
+# GCP setup for local development and maintenance
+
+Maintainer access to the staging project (`neuro-d3-staging`) uses your own Google identity with Application Default Credentials (ADC). No service account key files, no static keys.
+
+1. Install the gcloud CLI on Mac
+
+```
+brew install --cask google-cloud-sdk
+```
+
+2. Authenticate
+
+```
+gcloud auth login
+gcloud auth application-default login
+gcloud config set project neuro-d3-staging
+```
+
+`gcloud auth login` authorizes the CLI itself. `gcloud auth application-default login` writes the ADC file that client libraries (gcsfs, google-cloud-storage, Terraform) pick up automatically.
+
+3. Verify
+
+```
+gcloud projects describe neuro-d3-staging
+gcloud storage ls gs://neuro-d3-staging-find-reuse-cache/
+```
+
+The second command succeeds (possibly listing nothing) once the bucket exists and your identity has access. Project owners have access implicitly; otherwise ask a maintainer to grant `roles/storage.objectAdmin` on the bucket.
+
+4. Notes
+
+* On the staging GCE VM and inside its containers, credentials come from the attached `neuro-d3-airflow` service account via the metadata server. Nothing to configure there.
+* For unusual hosts (CI runners, non-GCP VMs), set `GOOGLE_APPLICATION_CREDENTIALS` to point at a provisioned ADC file, or use fixture seeding (`SEED_SOURCE=fixtures`) which needs no cloud access.


### PR DESCRIPTION
## Summary

* `deploy/gcp/staging/find_reuse_bucket.tf`: private, versioned `${project_id}-find-reuse-cache` bucket with uniform bucket-level access and `roles/storage.objectAdmin` granted to the Airflow VM service account only. No lifecycle rule touches live objects; a `num_newer_versions` rule cleans up noncurrent versions beyond the two most recent, and `force_destroy` stays off.
* The bucket is deliberately separate from `${project_id}-paper-mapping`, whose 30-day delete lifecycle is premised on contents being reproducible by re-running DAGs. The find_reuse cache (multi-source full-text fetches and tens of thousands of LLM classifications) is expensive to regenerate, so it gets durable storage.
* `docs/gcp_setup.md`: maintainer setup for Application Default Credentials via gcloud. No static keys anywhere.

The seeding plan this bucket is part of lives in the epic (#81) and its child issues, not in the repo.

Closes #82

## Validation

* `terraform validate` and `terraform fmt -check` pass (run via the `hashicorp/terraform:1.15` image with `terraform init -backend=false`).
* ADC read/write/delete confirmed from a workstation against an existing staging bucket, both via `gcloud storage` and via the `gcsfs` client path the seeding code will use.
* `terraform apply` and the ADC probe from the Airflow VM service account are still outstanding, per the acceptance criteria in #82 (the bucket does not exist until this is applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)