### PR TITLE
Add fsspec bucket access module for the find_reuse cache

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,14 @@ _PIP_ADDITIONAL_REQUIREMENTS=
 # Sign up at https://openrouter.ai/ and create an API key.
 OPENROUTER_API_KEY=sk-or-v1-xxxxxxxxxxxx
 
+# ─── find_reuse cache bucket ──────────────────────────────────
+# fsspec URL for the cache object store (paper full text, classification and
+# dataset snapshots, seed manifest). Used by utils/bucket.py. Credentials are
+# ambient (ADC on GCP; gcloud auth application-default login on a workstation).
+# Leave unset for local work that does not touch the bucket; use a memory:// or
+# file:// URL to exercise the bucket code path offline.
+# FIND_REUSE_BUCKET_URL=gs://neuro-d3-staging-find-reuse-cache
+
 # ─── Database (only needed when running outside Docker) ───────
 # DB_HOST=localhost
 # DB_PORT=5432

--- a/airflow/dags/.airflowignore
+++ b/airflow/dags/.airflowignore
@@ -1,5 +1,7 @@
 # Ignore utility files - they are not DAGs
 utils/
+# Unit tests live alongside the DAGs but must not be parsed as DAGs.
+tests/
 __pycache__/
 *.pyc
 

--- a/airflow/dags/tests/conftest.py
+++ b/airflow/dags/tests/conftest.py
@@ -1,0 +1,14 @@
+"""
+Shared pytest setup for the DAG unit tests.
+
+Adds the ``dags`` directory (the parent of this ``tests`` package) to
+``sys.path`` so tests import modules the same way Airflow does at runtime
+(``from utils.bucket import ...``), where ``PYTHONPATH`` is ``/opt/airflow/dags``.
+"""
+
+import os
+import sys
+
+_DAGS_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _DAGS_DIR not in sys.path:
+    sys.path.insert(0, _DAGS_DIR)

--- a/airflow/dags/tests/test_bucket.py
+++ b/airflow/dags/tests/test_bucket.py
@@ -1,0 +1,99 @@
+"""
+Unit tests for ``utils.bucket``.
+
+All tests run against ``memory://`` or a ``file://`` temp directory, so they
+exercise the real fsspec read/write path with no live cloud calls.
+"""
+
+import hashlib
+import json
+
+import pytest
+
+from utils import bucket
+
+
+@pytest.fixture
+def memory_bucket(monkeypatch):
+    """Point the module at a unique in-memory bucket per test."""
+    url = f"memory://test-{bucket.__name__}"
+    monkeypatch.setenv(bucket.BUCKET_URL_ENV, url)
+    fs = bucket._filesystem(url)
+    # MemoryFileSystem state is process-global; clear anything a prior test left.
+    for path in fs.find(url):
+        fs.rm_file(path)
+    return url
+
+
+def test_put_get_bytes_roundtrip(memory_bucket):
+    sha, n = bucket.put_bytes("papers/abc/latest.json", b"hello world")
+    assert n == 11
+    assert sha == hashlib.sha256(b"hello world").hexdigest()
+    assert bucket.get_bytes("papers/abc/latest.json") == b"hello world"
+
+
+def test_put_get_json_roundtrip(memory_bucket):
+    obj = {"doi": "10.1/x", "full_text": "body", "authors": ["b", "a"]}
+    sha, n = bucket.put_json("papers/x/latest.json", obj)
+    assert bucket.get_json("papers/x/latest.json") == obj
+    # Hash and size correspond to the module's deterministic serialization.
+    expected = json.dumps(obj, sort_keys=True, ensure_ascii=False, separators=(",", ":")).encode()
+    assert sha == hashlib.sha256(expected).hexdigest()
+    assert n == len(expected)
+
+
+def test_put_json_is_deterministic(memory_bucket):
+    """Same object, different key insertion order, yields the same hash."""
+    sha1, _ = bucket.put_json("k1", {"a": 1, "b": 2})
+    sha2, _ = bucket.put_json("k2", {"b": 2, "a": 1})
+    assert sha1 == sha2
+
+
+def test_exists(memory_bucket):
+    assert bucket.exists("missing/key.json") is False
+    bucket.put_bytes("present/key.json", b"x")
+    assert bucket.exists("present/key.json") is True
+
+
+def test_get_missing_key_raises(memory_bucket):
+    with pytest.raises(FileNotFoundError):
+        bucket.get_bytes("nope/missing.json")
+
+
+def test_leading_slash_in_key_is_normalized(memory_bucket):
+    bucket.put_bytes("/papers/y/latest.json", b"data")
+    assert bucket.get_bytes("papers/y/latest.json") == b"data"
+
+
+def test_missing_env_raises(monkeypatch):
+    monkeypatch.delenv(bucket.BUCKET_URL_ENV, raising=False)
+    with pytest.raises(bucket.BucketConfigError):
+        bucket.exists("any/key")
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        ("gs://neuro-d3-staging-find-reuse-cache", "neuro-d3-staging-find-reuse-cache"),
+        ("gs://my-bucket/sub/prefix", "my-bucket"),
+        ("memory://fr-cache", "fr-cache"),
+    ],
+)
+def test_bucket_name(monkeypatch, url, expected):
+    monkeypatch.setenv(bucket.BUCKET_URL_ENV, url)
+    assert bucket.bucket_name() == expected
+
+
+def test_trailing_slash_in_url_is_stripped(monkeypatch):
+    monkeypatch.setenv(bucket.BUCKET_URL_ENV, "memory://fr-cache/")
+    bucket.put_bytes("papers/z.json", b"q")
+    assert bucket.get_bytes("papers/z.json") == b"q"
+
+
+def test_file_url_roundtrip(monkeypatch, tmp_path):
+    """A file:// URL exercises the same path against the local filesystem."""
+    monkeypatch.setenv(bucket.BUCKET_URL_ENV, f"file://{tmp_path}")
+    sha, n = bucket.put_json("papers/local/latest.json", {"ok": True})
+    assert bucket.get_json("papers/local/latest.json") == {"ok": True}
+    assert (tmp_path / "papers" / "local" / "latest.json").exists()
+    assert n > 0 and len(sha) == 64

--- a/airflow/dags/utils/bucket.py
+++ b/airflow/dags/utils/bucket.py
@@ -1,0 +1,123 @@
+"""
+Object-storage access for the find_reuse cache.
+
+All reads and writes of cache objects (paper full text, classification and
+dataset snapshots, the seed manifest) go through this module. The backing store
+is configured by a single environment variable, ``FIND_REUSE_BUCKET_URL``, an
+fsspec URL such as ``gs://neuro-d3-staging-find-reuse-cache``. GCS is the store
+in staging; because access is via fsspec, ``file://`` and ``memory://`` URLs
+work unchanged for local development and tests, and any other fsspec-supported
+store is a configuration change rather than a code change.
+
+Credentials are ambient. On the Airflow VM and its containers, gcsfs picks up
+the attached service account from the metadata server; on a workstation it picks
+up ``gcloud auth application-default login``. ``GOOGLE_APPLICATION_CREDENTIALS``
+is the standard escape hatch for hosts where neither applies.
+
+Keys passed to these functions are always relative to the configured bucket URL
+(for example ``papers/<sha>/latest.json``, as produced by
+``utils.cache_keys.paper_cache_key_for_doi``). The key only, never a full URL,
+is what callers persist (for example in ``papers.fulltext_object_key``), so rows
+stay portable across providers.
+
+Connection and authentication errors propagate to the caller. This module does
+not retry and does not fall back to a different store.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from functools import lru_cache
+from typing import Any, Tuple
+from urllib.parse import urlsplit
+
+import fsspec
+
+BUCKET_URL_ENV = "FIND_REUSE_BUCKET_URL"
+
+# Serialization used for every JSON object written through this module. Fixed and
+# deterministic so a given object always produces the same bytes and the same
+# sha256, which is what makes hash-based idempotency (skip upload when the stored
+# object already matches) reliable.
+_JSON_KWARGS = {"sort_keys": True, "ensure_ascii": False, "separators": (",", ":")}
+
+
+class BucketConfigError(RuntimeError):
+    """Raised when the bucket URL is not configured."""
+
+
+def _bucket_url() -> str:
+    """Return the configured bucket URL with any trailing slash removed."""
+    url = os.environ.get(BUCKET_URL_ENV)
+    if not url or not url.strip():
+        raise BucketConfigError(
+            f"{BUCKET_URL_ENV} is not set. Point it at the cache bucket, "
+            "e.g. gs://neuro-d3-staging-find-reuse-cache (or memory://... for tests)."
+        )
+    return url.strip().rstrip("/")
+
+
+@lru_cache(maxsize=None)
+def _filesystem(url: str) -> fsspec.AbstractFileSystem:
+    """Return the fsspec filesystem for a bucket URL's protocol, cached per URL."""
+    protocol = urlsplit(url).scheme or "file"
+    if protocol in ("file", "local"):
+        # Object stores create intermediate prefixes implicitly; the local
+        # filesystem does not, so writing a nested key needs the parent dirs
+        # created first. auto_mkdir handles that for file:// dev and tests.
+        return fsspec.filesystem(protocol, auto_mkdir=True)
+    return fsspec.filesystem(protocol)
+
+
+def _full_path(key: str) -> str:
+    """Join a relative cache key onto the configured bucket URL."""
+    return f"{_bucket_url()}/{key.lstrip('/')}"
+
+
+def bucket_name() -> str:
+    """
+    Return the bucket name from the configured URL, for storing alongside object
+    keys (for example in ``papers.fulltext_bucket``). For ``gs://`` this is the
+    GCS bucket; for ``memory://`` it is the in-memory namespace.
+    """
+    url = _bucket_url()
+    split = urlsplit(url)
+    if split.netloc:
+        return split.netloc
+    # file:// URLs carry the path in `path`; fall back to its first segment.
+    return split.path.lstrip("/").split("/", 1)[0]
+
+
+def exists(key: str) -> bool:
+    """Return whether an object exists at ``key``."""
+    return _filesystem(_bucket_url()).exists(_full_path(key))
+
+
+def get_bytes(key: str) -> bytes:
+    """Return the raw bytes at ``key``. Raises ``FileNotFoundError`` if absent."""
+    return _filesystem(_bucket_url()).cat_file(_full_path(key))
+
+
+def put_bytes(key: str, body: bytes) -> Tuple[str, int]:
+    """
+    Write ``body`` to ``key``. Returns the ``(sha256_hex, byte_count)`` of the
+    written content, for integrity tracking by callers.
+    """
+    _filesystem(_bucket_url()).pipe_file(_full_path(key), body)
+    return hashlib.sha256(body).hexdigest(), len(body)
+
+
+def get_json(key: str) -> Any:
+    """Return the JSON object stored at ``key``. Raises ``FileNotFoundError`` if absent."""
+    return json.loads(get_bytes(key).decode("utf-8"))
+
+
+def put_json(key: str, obj: Any) -> Tuple[str, int]:
+    """
+    Serialize ``obj`` to JSON (deterministically) and write it to ``key``.
+    Returns the ``(sha256_hex, byte_count)`` of the written bytes.
+    """
+    body = json.dumps(obj, **_JSON_KWARGS).encode("utf-8")
+    return put_bytes(key, body)

--- a/airflow/requirements.txt
+++ b/airflow/requirements.txt
@@ -8,3 +8,8 @@
 # official constraints file or pin a compatible provider version.
 apache-airflow-providers-google
 
+# fsspec GCS backend for utils/bucket.py (find_reuse cache access). Declared
+# explicitly rather than relying on it arriving transitively via the Google
+# provider, so the bucket module's gs:// reads/writes don't depend on provider
+# packaging. Pulls fsspec as a dependency.
+gcsfs

--- a/deploy/gcp/staging/docker-compose.gce.yml
+++ b/deploy/gcp/staging/docker-compose.gce.yml
@@ -49,6 +49,9 @@ x-airflow-common:
     AIRFLOW__LOGGING__REMOTE_LOGGING: 'true'
     AIRFLOW__LOGGING__REMOTE_LOG_CONN_ID: 'google_cloud_default'
     AIRFLOW_CONN_GOOGLE_CLOUD_DEFAULT: 'google-cloud-platform://'
+    # find_reuse cache bucket (utils/bucket.py). ADC from the VM service account
+    # via the google_cloud_default conn above; no static keys.
+    FIND_REUSE_BUCKET_URL: gs://neuro-d3-staging-find-reuse-cache
     # App-data DB (the `dag_data` database) used by DAG tasks via utils/database.py.
     # Same Cloud SQL instance as the metadata DB, reached through the proxy sidecar.
     # These are the switch utils/environment.py keys off of (DB_HOST set => hosted).

--- a/docker-compose.pr.yml
+++ b/docker-compose.pr.yml
@@ -38,6 +38,9 @@ x-airflow-common:
     _PIP_ADDITIONAL_REQUIREMENTS: ${_PIP_ADDITIONAL_REQUIREMENTS:-}
     # OpenRouter API key for LLM-based paper reuse classification DAG.
     OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:-}
+    # fsspec URL for the find_reuse cache bucket (utils/bucket.py). The seed-init
+    # service reads it; PR envs on GCP authenticate via the VM's ADC.
+    FIND_REUSE_BUCKET_URL: ${FIND_REUSE_BUCKET_URL:-}
   volumes:
     - ./airflow/dags:/opt/airflow/dags
     - ./airflow/logs:/opt/airflow/logs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,9 @@ x-airflow-common:
     _PIP_ADDITIONAL_REQUIREMENTS: ${_PIP_ADDITIONAL_REQUIREMENTS:-}
     # OpenRouter API key for LLM-based paper reuse classification DAG.
     OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:-}
+    # fsspec URL for the find_reuse cache bucket (utils/bucket.py). Optional
+    # locally; set to a gs://, file://, or memory:// URL to exercise the bucket.
+    FIND_REUSE_BUCKET_URL: ${FIND_REUSE_BUCKET_URL:-}
   volumes:
     - ./airflow/dags:/opt/airflow/dags
     - ./airflow/logs:/opt/airflow/logs


### PR DESCRIPTION
## Summary

Implements **#84**: one module, `airflow/dags/utils/bucket.py`, for all object-storage access to the find_reuse cache. Backed by fsspec and configured by a single `FIND_REUSE_BUCKET_URL` env var (e.g. `gs://neuro-d3-staging-find-reuse-cache`), so GCS is the store in staging while `file://` and `memory://` work unchanged for offline dev and tests. Three issues (#83, #85, #87) depend on this.

- **`utils/bucket.py`**: `get_bytes` / `put_bytes` / `get_json` / `put_json` / `exists` / `bucket_name`. Puts return `(sha256_hex, byte_count)` for integrity tracking; JSON is serialized deterministically (`sort_keys`, compact separators) so the same object always yields the same hash, which is what makes hash-based idempotency reliable downstream. Keys are always relative (`papers/<sha>/latest.json`); the key only, never a full URL, is what callers persist. Credentials are ambient (ADC); connection/auth errors propagate with no retries and no fallback.
- **`airflow/requirements.txt`**: adds `gcsfs` explicitly rather than relying on it arriving transitively via `apache-airflow-providers-google`.
- **Compose + env**: wires `FIND_REUSE_BUCKET_URL` into the local, PR, and GCE env blocks and `.env.example`. The GCE staging file hardcodes the staging bucket (consistent with how it hardcodes other staging specifics); local/PR default it to empty.
- **`airflow/dags/tests/`**: new unit-test home with `test_bucket.py` (round-trips, hashes, missing-key, `bucket_name`, leading-slash and trailing-slash handling, `file://` portability) against `memory://`/`file://`, plus a `conftest.py` that mirrors the runtime import path. `tests/` is added to `.airflowignore` so the DAG processor never parses them.

## Paths note

The epic/issues were written against a `dags/...` layout, but the "central directory" refactor on `main` moved everything under `airflow/` (`airflow/dags/utils/`, `airflow/requirements.txt`, etc.). This PR uses the real `airflow/...` locations. The issue text is stale on this point and could use a sweep.

## Validation

- `pytest tests/test_bucket.py` → **12 passed** (run in a clean venv with `pytest` + `fsspec`; `memory://`/`file://` need no gcsfs or network).
- `docker compose -f docker-compose.yml config` and `-f docker-compose.pr.yml config` parse cleanly.
- Python byte-compiles; no repo linter/formatter is configured.
- Not run: any live GCS call (by design, the module's cloud path is exercised at runtime via ADC; `#82`'s bucket isn't applied yet).

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)